### PR TITLE
Fix for iOS 11

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A workaround for this bug appeared in a fork of autosize project:
 
 #### [Workaround for ios 11 bug](https://github.com/jhubble/autosize/commit/18e747124271c7d59362a4a34455dceebf4ed6b0)
 
-To avoid third part changes, this fork was created for ISAO internal use.
+To avoid third part changes, this fork was created for ISAO internal use. And should be abandoned when [autosize](https://github.com/jackmoore/autosize) implements the fix on future versions.
 
 ## Summary
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,15 @@
+# Important!
+
+This repository was created to workaround a know bug of autosize plugin on iOS 11 as reported on the original repository.
+
+#### [iOS 11.0.3, input box autosize is overlapping the keypad](https://github.com/jackmoore/autosize/issues/343)
+
+A workaround for this bug appeared in a fork of autosize project: 
+
+#### [Workaround for ios 11 bug](https://github.com/jhubble/autosize/commit/18e747124271c7d59362a4a34455dceebf4ed6b0)
+
+To avoid third part changes, this fork was created for ISAO internal use.
+
 ## Summary
 
 Autosize is a small, stand-alone script to automatically adjust textarea height to fit text.

--- a/src/autosize.js
+++ b/src/autosize.js
@@ -119,10 +119,12 @@ function assign(ta) {
 		// used to check if an update is actually necessary on window.resize
 		clientWidth = ta.clientWidth;
 
-		// prevents scroll-position jumping
-		overflows.forEach(el => {
-			el.node.scrollTop = el.scrollTop
-		});
+        /* This commented out code breaks causes the keyboard to overlay the input box on IOS 11
+        // prevents scroll-position jumping
+        overflows.forEach(el => {
+        	el.node.scrollTop = el.scrollTop
+        });
+        */
 
 		if (docTop) {
 			document.documentElement.scrollTop = docTop;


### PR DESCRIPTION
Issue: https://jira.goalous.com/browse/GL-6729

This fix the issue listed on the main repository:

[iOS 11.0.3, input box autosize is overlapping the keypad](https://github.com/jackmoore/autosize/issues/343)

And implemented on the fork: 

[Workaround for ios 11 bug](https://github.com/jhubble/autosize/commit/18e747124271c7d59362a4a34455dceebf4ed6b0)